### PR TITLE
Standardise on tabs for indentation.

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -49,8 +49,8 @@ class TDPrinting ( Workbench ):
 	MenuText = "3D Printing"
 	ToolTip = "Workbench for 3D Printing"
 
-        def GetClassName(self):
-               return "Gui::PythonWorkbench"
+	def GetClassName(self):
+		return "Gui::PythonWorkbench"
 
 	def Initialize(self):
 		#import myModule1, myModule2
@@ -62,11 +62,11 @@ class TDPrinting ( Workbench ):
 		Log ("Loading MyModule... done\n")
 
 	def Activated(self):
-               # do something here if needed...
+		# do something here if needed...
 		Msg ("MyWorkbench.Activated()\n")
 
 	def Deactivated(self):
-               # do something here if needed...
+		# do something here if needed...
 		Msg ("MyWorkbench.Deactivated()\n")
 
 FreeCADGui.addWorkbench(TDPrinting)


### PR DESCRIPTION
Solves: During initialization the error inconsistent use of tabs and spaces in indentation (<string>, line 52) occurred in ~/.FreeCAD/Mod/FreeCAD-CuraEngine-Plugin/InitGui.py
Please look into the log file for further information